### PR TITLE
不要なためデフォルト値を変更した

### DIFF
--- a/db/migrate/20251122044514_remove_default_from_entries_event_id.rb
+++ b/db/migrate/20251122044514_remove_default_from_entries_event_id.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromEntriesEventId < ActiveRecord::Migration[7.0]
+  def change
+    change_column_default :entries, :event_id, from: 1, to: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2025_11_15_120149) do
+ActiveRecord::Schema[7.0].define(version: 2025_11_22_044514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[7.0].define(version: 2025_11_15_120149) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "description"
-    t.bigint "event_id", default: 1, null: false
+    t.bigint "event_id", null: false
     t.index ["category_id"], name: "index_entries_on_category_id"
     t.index ["event_id"], name: "index_entries_on_event_id"
     t.index ["user_id"], name: "index_entries_on_user_id"


### PR DESCRIPTION
## 概要
`entries` テーブルの `event_id` に設定されていたデフォルト値（default: 1）を削除しました。

## 背景
もともとが１回限りの想定だったためイベントテーブルがありませんでした。
すでにエントリーされているイベントに１というIDを付与するために仮につけていただけなので、削除しました。
